### PR TITLE
helm chart allow image tage to be overwritten

### DIFF
--- a/helm/charts/scheduled-volume-snapshotter/README.md
+++ b/helm/charts/scheduled-volume-snapshotter/README.md
@@ -12,6 +12,7 @@ Values which can be overridden are documented below.
 | Parameter                     | Description                                                              | Default                                  |
 | ----------------------------- | ------------------------------------------------------------------------ | ---------------------------------------- |
 | `image.repository`            | The image to be used for the CronJob                                     | `ryaneorth/scheduled-volume-snapshotter` |
+| `image.tag`                   | The image version to be used for the CronJob. <br> If not specified the Chart App Version will be used | `.Chart.AppVersion`                      |
 | `image.pullPolicy`            | The pull policy for the CronJob pods                                     | `IfNotPresent`                           |
 | `schedule`                    | The cron expression for how often the job should execute                 | `*/15 * * * *`                           |
 | `successfulJobsHistoryLimit`  | The number of successful jobs to retain                                  | `3`                                      |

--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           serviceAccountName: {{ include "scheduled-snapshot-operator.name" . }}
           containers:
             - name: {{ .Chart.Name }}
-              image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               resources:
 {{ toYaml .Values.resources | indent 16 }}

--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           serviceAccountName: {{ include "scheduled-snapshot-operator.name" . }}
           containers:
             - name: {{ .Chart.Name }}
-              image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               resources:
 {{ toYaml .Values.resources | indent 16 }}

--- a/helm/charts/scheduled-volume-snapshotter/values.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/values.yaml
@@ -1,5 +1,6 @@
 image:
   repository: ryaneorth/scheduled-volume-snapshotter
+  #tag: latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
added the option to overwrite the container image in the helm chart
fallback is existing behavior to use chart app version as container image version