### PR TITLE
feat: add maxSnapshotCount parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:3.9.16-slim-bullseye
 
 WORKDIR /
 
-COPY snapshotter.py .
-
 COPY requirements.txt .
 
 RUN apt-get update \
@@ -13,5 +11,7 @@ RUN apt-get update \
     && pip install --no-cache-dir --upgrade pip==23.3 setuptools==70.0.0 \
     && pip install --no-cache-dir -r requirements.txt \
     && rm requirements.txt
+
+COPY snapshotter.py .
 
 ENTRYPOINT ["python", "-u", "snapshotter.py"]

--- a/helm/charts/scheduled-volume-snapshotter/README.md
+++ b/helm/charts/scheduled-volume-snapshotter/README.md
@@ -8,23 +8,24 @@ helm upgrade --install scheduled-volume-snapshotter scheduled-volume-snapshotter
 ```
 
 
-| Parameter                     | Description                                                                                            | Default                                  |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------| ---------------------------------------- |
-| `cronLabels`                  | Additional labels to add to the CronJob                                                                | `{}`                                     |
-| `image.repository`            | The image to be used for the CronJob                                                                   | `ryaneorth/scheduled-volume-snapshotter` |
-| `image.tag`                   | The image version to be used for the CronJob. <br> If not specified the Chart App Version will be used | `.Chart.AppVersion`                      |
-| `image.pullPolicy`            | The pull policy for the CronJob pods                                                                   | `IfNotPresent`                           |
-| `schedule`                    | The cron expression for how often the job should execute                                               | `*/15 * * * *`                           |
-| `successfulJobsHistoryLimit`  | The number of successful jobs to retain                                                                | `3`                                      |
-| `failedJobsHistoryLimit`      | The number of failed jobs to retain                                                                    | `1`                                      |
-| `rbac.enabled`                | Flag indicating whether the rbac resources should be installed                                         | `true`                                   |
-| `logLevel`                    | The Python log level for the jobs                                                                      | `INFO`                                   |
-| `ignoreUnsuccessfulSnapshots` | Flag indicating if previously generated snapshots in a non-successful state should be considered when determining if a new snapshot needs to be generated                                                                      | `false`                                   |
-| `podLabels`                   | Additional labels to add to the CronJob pods                                                           | `{}`                                     |
-| `podAnnotations`              | Annotations to be added to pods                                                                        | `{}`                                     |
-| `snapshotClasses`             | Optional list of VolumeSnapshotClass resources                                                         | `[]`                                     |
-| `snapshots`                   | Optional list of ScheduledVolumeSnapshot resources                                                     | `[]`                                     |
-| `podSecurityContext`          | The securityContext to apply to the CronJob pods                                                       | `{}`                                     |
-| `containerSecurityContext`    | The securityContext to apply to the CronJob pods' container                                            | `{}`                                     |
-| `imagePullSecrets`            | The imagePullSecrets to apply to the CronJob pods                                                      | `[]`                                     |
-| `startingDeadlineSeconds`     | The startingDeadlineSeconds to apply to the CronJob                                                    | `300`                                    |
+| Parameter                     | Description                                                                                                                                               | Default                                  |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| `cronLabels`                  | Additional labels to add to the CronJob                                                                                                                   | `{}`                                     |
+| `image.repository`            | The image to be used for the CronJob                                                                                                                      | `ryaneorth/scheduled-volume-snapshotter` |
+| `image.tag`                   | The image version to be used for the CronJob. <br> If not specified the Chart App Version will be used                                                    | `.Chart.AppVersion`                      |
+| `image.pullPolicy`            | The pull policy for the CronJob pods                                                                                                                      | `IfNotPresent`                           |
+| `schedule`                    | The cron expression for how often the job should execute                                                                                                  | `*/15 * * * *`                           |
+| `successfulJobsHistoryLimit`  | The number of successful jobs to retain                                                                                                                   | `3`                                      |
+| `failedJobsHistoryLimit`      | The number of failed jobs to retain                                                                                                                       | `1`                                      |
+| `rbac.enabled`                | Flag indicating whether the rbac resources should be installed                                                                                            | `true`                                   |
+| `logLevel`                    | The Python log level for the jobs                                                                                                                         | `INFO`                                   |
+| `ignoreUnsuccessfulSnapshots` | Flag indicating if previously generated snapshots in a non-successful state should be considered when determining if a new snapshot needs to be generated | `false`                                  |
+| `maxSnapshotCount`            | Specify how many snapshots can be done in one cron job. Useful to mitigate storage API throttling issues. `0` means no limit                              | `0`                                      |
+| `podLabels`                   | Additional labels to add to the CronJob pods                                                                                                              | `{}`                                     |
+| `podAnnotations`              | Annotations to be added to pods                                                                                                                           | `{}`                                     |
+| `snapshotClasses`             | Optional list of VolumeSnapshotClass resources                                                                                                            | `[]`                                     |
+| `snapshots`                   | Optional list of ScheduledVolumeSnapshot resources                                                                                                        | `[]`                                     |
+| `podSecurityContext`          | The securityContext to apply to the CronJob pods                                                                                                          | `{}`                                     |
+| `containerSecurityContext`    | The securityContext to apply to the CronJob pods' container                                                                                               | `{}`                                     |
+| `imagePullSecrets`            | The imagePullSecrets to apply to the CronJob pods                                                                                                         | `[]`                                     |
+| `startingDeadlineSeconds`     | The startingDeadlineSeconds to apply to the CronJob                                                                                                       | `300`                                    |

--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -52,4 +52,6 @@ spec:
                   value: "{{ .Values.logLevel }}"
                 - name: IGNORE_UNSUCCESSFUL_SNAPSHOTS
                   value: "{{ .Values.ignoreUnsuccessfulSnapshots }}"
+                - name: MAX_SNAPHOT_COUNT
+                  value: "{{ .Values.maxSnapshotCount | default 0 }}"
           restartPolicy: Never

--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -52,6 +52,6 @@ spec:
                   value: "{{ .Values.logLevel }}"
                 - name: IGNORE_UNSUCCESSFUL_SNAPSHOTS
                   value: "{{ .Values.ignoreUnsuccessfulSnapshots }}"
-                - name: MAX_SNAPHOT_COUNT
+                - name: MAX_SNAPSHOT_COUNT
                   value: "{{ .Values.maxSnapshotCount | default 0 }}"
           restartPolicy: Never

--- a/helm/charts/scheduled-volume-snapshotter/values.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/values.yaml
@@ -26,6 +26,8 @@ logLevel: INFO
 
 ignoreUnsuccessfulSnapshots: false
 
+maxSnapshotCount: 0
+
 resources:
   limits:
     cpu: 100m

--- a/snapshotter.py
+++ b/snapshotter.py
@@ -14,7 +14,7 @@ K8S_VERSION_INFO = kubernetes.client.VersionApi().get_code()
 K8S_MAJOR_VERSION = int(re.split('[^0-9]', K8S_VERSION_INFO.major)[0])
 K8S_MINOR_VERSION = int(re.split('[^0-9]', K8S_VERSION_INFO.minor)[0])
 IGNORE_UNSUCCESSFUL_SNAPSHOTS = os.getenv('IGNORE_UNSUCCESSFUL_SNAPSHOTS', 'false').lower() == 'true'
-MAX_SNAPSHOT_COUNT = os.getenv('MAX_SNAPSHOT_COUNT', 0)
+MAX_SNAPSHOT_COUNT = int(os.getenv('MAX_SNAPSHOT_COUNT', 0))
 
 SVS_CRD_GROUP = 'k8s.ryanorth.io'
 SVS_CRD_VERSION = 'v1beta1'


### PR DESCRIPTION
This PR adds a new parameter to limit the number of snaphots done in one cronjob run. I've not tested it yet.

I'm more a Perl guy than Python guy, so feel free to fix style issues :wink:

The goal is to mitigate storage API throttling seen on Azure (see this [blog](https://ddumont.wordpress.com/2025/01/18/how-we-solved-storage-api-throttling-on-our-azure-kubernetes-clusters/) for the full story).

I think the other idea to limit the number of concurrent snapshot may be useful, but it is more than I can handle. I'll let you add it if you wish so.

Closes: #30